### PR TITLE
Fix missing required icon prop warning

### DIFF
--- a/src/views/AppContent/ItemsOverview.vue
+++ b/src/views/AppContent/ItemsOverview.vue
@@ -67,6 +67,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 						content: errorString,
 						trigger: 'manual',
 					}"
+					icon=""
 					:class="{ 'error': collectionNameError }"
 					@submit="addCollection"
 					@input="checkCollectionName">


### PR DESCRIPTION
Workaround until
https://github.com/nextcloud/nextcloud-vue/issues/2316 is fixed