### PR TITLE
Limit compatibility to Nextcloud 25

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,15 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4']
-        nextcloud-versions: ['stable23']
+        php-versions: ['7.4']
+        nextcloud-versions: ['stable23', 'stable24', 'stable25']
         include:
-          - php-versions: '7.4'
-            nextcloud-versions: 'master'
-          # - php-versions: '8.0'
-          #   nextcloud-versions: 'stable21'
-          # - php-versions: '8.0'
-          #   nextcloud-versions: 'master'
+          - php-versions: '7.3'
+            nextcloud-versions: 'stable23'
     name: php${{ matrix.php-versions }} on ${{ matrix.nextcloud-versions }} unit tests
     env:
       CI: true

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 	<website>https://github.com/raimund-schluessler/inventory</website>
 	<bugs>https://github.com/raimund-schluessler/inventory/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="23" max-version="26"/>
+		<nextcloud min-version="23" max-version="25"/>
 	</dependencies>
 	<navigations>
 		<navigation>


### PR DESCRIPTION
Due to changes in Nextcloud 26 (https://github.com/nextcloud/server/pull/34490), the app is currently not compatible. This PR limits the version to Nextcloud 25.