### PR TITLE
Don't use tag prop on RouterLink

### DIFF
--- a/src/components/EntityTable/Collection.vue
+++ b/src/components/EntityTable/Collection.vue
@@ -37,7 +37,6 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 		</div>
 		<div class="column">
 			<RouterLink :to="`/${collection}/${encodePath(entity.path)}`"
-				tag="a"
 				@click.ctrl.prevent>
 				<div class="thumbnail">
 					<div :style="{ backgroundImage: getThumbnailUrl }"

--- a/src/components/EntityTable/Item.vue
+++ b/src/components/EntityTable/Item.vue
@@ -38,9 +38,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			</label>
 		</div>
 		<div class="column">
-			<component :is="itemRoute ? 'RouterLink': 'a'"
+			<component :is="itemRoute ? 'RouterLink' : 'a'"
 				:to="itemRoute"
-				tag="a"
 				@click.ctrl.prevent>
 				<div class="thumbnail">
 					<img v-if="entity.images.length > 0" :src="imageSrc" class="thumbnail__image">
@@ -53,9 +52,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			</component>
 		</div>
 		<div class="column">
-			<component :is="itemRoute ? 'RouterLink': 'a'"
+			<component :is="itemRoute ? 'RouterLink' : 'a'"
 				:to="itemRoute"
-				tag="a"
 				@click.ctrl.prevent>
 				<div class="text" :class="{'text--singleline': showInstance}">
 					<span>{{ entity.maker }}</span>
@@ -64,9 +62,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			</component>
 		</div>
 		<div class="column">
-			<component :is="itemRoute ? 'RouterLink': 'a'"
+			<component :is="itemRoute ? 'RouterLink' : 'a'"
 				:to="itemRoute"
-				tag="a"
 				@click.ctrl.prevent>
 				<div class="text" :class="{'text--singleline': showInstance}">
 					<span>{{ entity.description }}</span>


### PR DESCRIPTION
The `tag` prop is deprecated in v3 and not supported in v4 anymore.