### PR TITLE
Bump nextcloud/vue from 7.8.4 to 7.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@nextcloud/l10n": "2.1.0",
 				"@nextcloud/moment": "1.2.1",
 				"@nextcloud/router": "2.0.1",
-				"@nextcloud/vue": "7.8.4",
+				"@nextcloud/vue": "7.9.0",
 				"@vueuse/components": "^9.13.0",
 				"bwip-js": "3.4.0",
 				"date-fns": "^2.29.3",
@@ -2809,6 +2809,19 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@nextcloud/calendar-js": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.0.tgz",
+			"integrity": "sha512-kZBRFIG8J3TNU6K92iEpNzBa3r9JbpCr1MZFJHqVy/5+xTtQG9FqsHhqUWptPwLEBhUNMwN+oCCa7QJAnBKKyg==",
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"ical.js": "^1.5.0",
+				"uuid": "^9.0.0"
+			}
+		},
 		"node_modules/@nextcloud/capabilities": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.0.4.tgz",
@@ -3046,15 +3059,15 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.8.4.tgz",
-			"integrity": "sha512-rUdLwB/9aPtBNgo6H0dDVCEaFctbePp6NwH/uPJ10h67pzra+KcUqVvVEvaXxTwFTVf36K/WrGQAGY+0fV+bdg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.9.0.tgz",
+			"integrity": "sha512-ZT2/xuQNzA3HiBcZnqtLNidhyi/HzWL9IIf/l3ADlYTl32es2E32EC87nX4GKML435+apadb/OYCDSdocHqmcg==",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/browser-storage": "^0.2.0",
-				"@nextcloud/calendar-js": "^5.0.3",
+				"@nextcloud/calendar-js": "^6.0.0",
 				"@nextcloud/capabilities": "^1.0.4",
 				"@nextcloud/dialogs": "^4.0.0",
 				"@nextcloud/event-bus": "^3.0.0",
@@ -3104,28 +3117,6 @@
 			"integrity": "sha512-nDtoFowunZIaiq5N28Qvbq2CkUWEbvLrj41OYQx8/qw7Dpmm2bOUKAqjUrr8H1NdoNpCN7VyL5gyoWvwC3m+WQ==",
 			"peerDependencies": {
 				"vue": "2.x"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/calendar-js": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-5.0.3.tgz",
-			"integrity": "sha512-x6xvQKmuaO/Z/S6uK6qxGAJSaPOAM7DUhe+sJ1QEQAgUx9WIhaJOU+zYw2vdn8hiQ9R4gxfp/bgb6B0I+QBZvw==",
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"ical.js": "^1.5.0",
-				"uuid": "^8.3.2"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"peer": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@nextcloud/webpack-vue-config": {
@@ -19773,6 +19764,12 @@
 			"integrity": "sha512-1Tpkof2e9Q0UicHWahQnXXrubJoqyiaqsH9G52v3cjGeVeH3BCfa1FOa41eBwBSFe2/Jxj/wCH2YVLgIXpWbBg==",
 			"dev": true
 		},
+		"@nextcloud/calendar-js": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.0.tgz",
+			"integrity": "sha512-kZBRFIG8J3TNU6K92iEpNzBa3r9JbpCr1MZFJHqVy/5+xTtQG9FqsHhqUWptPwLEBhUNMwN+oCCa7QJAnBKKyg==",
+			"requires": {}
+		},
 		"@nextcloud/capabilities": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.0.4.tgz",
@@ -19954,15 +19951,15 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.8.4.tgz",
-			"integrity": "sha512-rUdLwB/9aPtBNgo6H0dDVCEaFctbePp6NwH/uPJ10h67pzra+KcUqVvVEvaXxTwFTVf36K/WrGQAGY+0fV+bdg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.9.0.tgz",
+			"integrity": "sha512-ZT2/xuQNzA3HiBcZnqtLNidhyi/HzWL9IIf/l3ADlYTl32es2E32EC87nX4GKML435+apadb/OYCDSdocHqmcg==",
 			"requires": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/browser-storage": "^0.2.0",
-				"@nextcloud/calendar-js": "^5.0.3",
+				"@nextcloud/calendar-js": "^6.0.0",
 				"@nextcloud/capabilities": "^1.0.4",
 				"@nextcloud/dialogs": "^4.0.0",
 				"@nextcloud/event-bus": "^3.0.0",
@@ -20000,20 +19997,6 @@
 				"vue-material-design-icons": "^5.1.2",
 				"vue-multiselect": "^2.1.6",
 				"vue2-datepicker": "^3.11.0"
-			},
-			"dependencies": {
-				"@nextcloud/calendar-js": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-5.0.3.tgz",
-					"integrity": "sha512-x6xvQKmuaO/Z/S6uK6qxGAJSaPOAM7DUhe+sJ1QEQAgUx9WIhaJOU+zYw2vdn8hiQ9R4gxfp/bgb6B0I+QBZvw==",
-					"requires": {}
-				},
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-					"peer": true
-				}
 			}
 		},
 		"@nextcloud/vue-select": {
@@ -20026,7 +20009,7 @@
 			"version": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#7e978bb6726cabbcbd86c071cc80ba15f029c026",
 			"integrity": "sha512-bKlGYEqblSiSHNmpaGM9fz/f9v6JNwHp63V63yaI26gE0Zs+DpZSzJWC6HWWbJ1BgmoKT7wLN1GJc4W/NxvnxQ==",
 			"dev": true,
-			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#7e978bb6726cabbcbd86c071cc80ba15f029c026",
+			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#master",
 			"requires": {}
 		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@nextcloud/l10n": "2.1.0",
 		"@nextcloud/moment": "1.2.1",
 		"@nextcloud/router": "2.0.1",
-		"@nextcloud/vue": "7.8.4",
+		"@nextcloud/vue": "7.9.0",
 		"@vueuse/components": "^9.13.0",
 		"bwip-js": "3.4.0",
 		"date-fns": "^2.29.3",

--- a/src/views/AppContent/ItemDetails.vue
+++ b/src/views/AppContent/ItemDetails.vue
@@ -26,7 +26,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				<NcBreadcrumbs>
 					<NcBreadcrumb v-for="(crumb, index) in breadcrumbs"
 						:key="crumb.path"
-						:title="crumb.title"
+						:name="crumb.name"
 						:to="crumb.path">
 						<template #icon>
 							<component :is="breadcrumbIcon"
@@ -382,15 +382,15 @@ export default {
 		breadcrumbs() {
 			const path = this.path
 			const crumbs = (!path || path === '') ? [] : path.split('/')
-			const breadcrumbs = [{ title: t('inventory', 'Items'), path: `/${this.collection}/` }].concat(crumbs.map((crumb, i) => {
+			const breadcrumbs = [{ name: t('inventory', 'Items'), path: `/${this.collection}/` }].concat(crumbs.map((crumb, i) => {
 				return {
-					title: crumb,
+					name: crumb,
 					path: `/${this.collection}/` + encodePath(crumbs.slice(0, i + 1).join('/')),
 				}
 			}))
 			if (this.item && !this.loadingItem) {
 				return breadcrumbs.concat([{
-					title: this.item.description,
+					name: this.item.description,
 					path: `/${this.collection}/${(this.path) ? encodePath(this.path) + '/' : ''}item-${this.id}${(this.instanceId) ? `/instance-${this.instanceId}` : ''}`,
 				}])
 			}

--- a/src/views/AppContent/ItemsOverview.vue
+++ b/src/views/AppContent/ItemsOverview.vue
@@ -25,7 +25,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			<NcBreadcrumbs @dropped="moveEntities">
 				<NcBreadcrumb v-for="(crumb, index) in breadcrumbs"
 					:key="crumb.path"
-					:title="crumb.title"
+					:name="crumb.name"
 					:to="crumb.path"
 					:disable-drop="index === (breadcrumbs.length - 1)">
 					<template #icon>
@@ -178,9 +178,9 @@ export default {
 		breadcrumbs() {
 			const path = this.path
 			const crumbs = (path === '') ? [] : path.split('/')
-			return [{ title: t('inventory', 'Items'), path: `/${this.collection}/` }].concat(crumbs.map((crumb, i) => {
+			return [{ name: t('inventory', 'Items'), path: `/${this.collection}/` }].concat(crumbs.map((crumb, i) => {
 				return {
-					title: crumb,
+					name: crumb,
 					path: `/${this.collection}/${crumbs.slice(0, i + 1).join('/')}`,
 				}
 			}))


### PR DESCRIPTION
This bumps nextcloud/vue from 7.8.4 to 7.9.0 and adjusts the `title` usage in `NcBreadcrumb`.